### PR TITLE
allow for 0 length signatures

### DIFF
--- a/src/FileSignatures/FileFormat.cs
+++ b/src/FileSignatures/FileFormat.cs
@@ -54,7 +54,7 @@ namespace FileSignatures
         /// <param name="offset">The offset at which the signature is located.</param>
         protected FileFormat(byte[] signature, int headerLength, string mediaType, string extension, int offset)
         {
-            if (signature == null || signature.Length == 0)
+            if (signature == null)
             {
                 throw new ArgumentNullException(nameof(signature));
             }


### PR DESCRIPTION
I have a use case where I would like to be able to override `IsMatch` to validate the stream but there is no consistent file signature.
It would be great if we were able to provide a zero-length header to support this use case.