### PR TITLE
use file format specific reader

### DIFF
--- a/src/FileSignatures/FileFormatInspector.cs
+++ b/src/FileSignatures/FileFormatInspector.cs
@@ -86,9 +86,9 @@ namespace FileSignatures
 
                 if(readers.Any())
                 {
-                    var file = readers[0].Read(stream);
                     foreach(var reader in readers)
                     {
+                        var file = reader.Read(stream);
                         if (!reader.IsMatch(file))
                         {
                             candidates.Remove((FileFormat)reader);


### PR DESCRIPTION
I ran into an issue where the `IDisposable` coming through to `IsMatch` was from a different `IFileFormatReader`.

All tests are currently passing but this does change the behaviour of potentially reading the stream multiple times based on the implementation of the `IFileFormatReader`s `Read` method.