### PR TITLE
Update documentation for bmp file type

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Currently, the following formats are built-in:
 | Name                       | Media-Type                                                                | Extension
 |----------------------------|---------------------------------------------------------------------------|--------
 | 3GPP                       | video/3gpp                                                                | .3gp
-| Bitmap                     | image/bitmap                                                              | .bmp
+| Bitmap                     | image/bmp                                                                 | .bmp
 | Excel                      | application/vnd.openxmlformats-officedocument.spreadsheetml.sheet         | .xlsx
 | Excel 97-2003              | application/vnd.ms-excel                                                  | .xls
 | Exe (Windows)              | application/octet-stream                                                  | .exe


### PR DESCRIPTION
Fix media-type for bitmap image content type in the documentation 
code property has image/bmp, but documentation refer to image/bitmap. all public documentation refer to image/bmp. 

https://github.com/neilharvey/FileSignatures/blob/master/src/FileSignatures/Formats/Bmp.cs
https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
https://www.iana.org/assignments/media-types/media-types.xhtml


```
string[] allowedType = { "image/bitmap", "image/gif", "image/jpeg", "image/png" };
var recognised = FileFormatLocator.GetFormats().Where(w=>allowedType.Contains(w.MediaType));
//does not contains bitmap

var allformats = FileFormatLocator.GetFormats();
//allformat contains image/bmp
```
