### PR TITLE
Dispose the result of reader read object, in case of OutOfMemoryExcep…

### DIFF
--- a/src/FileSignatures/FileFormatInspector.cs
+++ b/src/FileSignatures/FileFormatInspector.cs
@@ -86,7 +86,7 @@ namespace FileSignatures
 
                 if(readers.Any())
                 {
-                    var file = readers[0].Read(stream);
+                    using var file = readers[0].Read(stream);
                     foreach(var reader in readers)
                     {
                         if (!reader.IsMatch(file))


### PR DESCRIPTION
When inspect large amount files, it throws OutOfMemoryException.